### PR TITLE
fix(utils): replace deprecated APIs in mappings

### DIFF
--- a/lua/nvim-lsp-setup/utils.lua
+++ b/lua/nvim-lsp-setup/utils.lua
@@ -22,9 +22,9 @@ function M.default_mappings(bufnr, mappings)
         ['<space>rn'] = 'lua vim.lsp.buf.rename()',
         ['<space>ca'] = 'lua vim.lsp.buf.code_action()',
         ['<space>f'] = 'lua vim.lsp.buf.formatting()',
-        ['<space>e'] = 'lua vim.lsp.diagnostic.show_line_diagnostics()',
-        ['[d'] = 'lua vim.lsp.diagnostic.goto_prev()',
-        [']d'] = 'lua vim.lsp.diagnostic.goto_next()',
+        ['<space>e'] = 'lua vim.diagnostic.open_float()',
+        ['[d'] = 'lua vim.diagnostic.goto_prev()',
+        [']d'] = 'lua vim.diagnostic.goto_next()',
     }
     mappings = vim.tbl_deep_extend('keep', mappings or {}, defaults)
     M.mappings(bufnr, mappings)


### PR DESCRIPTION
For reference: https://github.com/neovim/nvim-lspconfig/pull/1532/files

![image](https://user-images.githubusercontent.com/27996771/166412933-d9e50746-6d02-4c61-a9b5-ca6661d2cee2.png)