### PR TITLE
Marking format_on_save timeout configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ require('nvim-lsp-setup').setup({
     -- gi = 'lua require"telescope.builtin".lsp_implementations()',
     -- gr = 'lua require"telescope.builtin".lsp_references()',
     mappings = {},
+    -- configurable format_on_save timeout
+    format_on_save_timeout = 1000,
     -- Global on_attach
     on_attach = function(client, bufnr)
         -- Support custom the on_attach function for global.

--- a/lua/nvim-lsp-setup/init.lua
+++ b/lua/nvim-lsp-setup/init.lua
@@ -8,7 +8,7 @@ local function lsp_servers(opts)
 
         config = vim.tbl_deep_extend('keep', config, {
             on_attach = function(client, bufnr)
-                utils.format_on_save(client)
+                utils.format_on_save(client, opts)
                 if opts.on_attach then
                     opts.on_attach(client, bufnr)
                 end

--- a/lua/nvim-lsp-setup/utils.lua
+++ b/lua/nvim-lsp-setup/utils.lua
@@ -40,13 +40,13 @@ function M.disable_formatting(client)
     end
 end
 
-function M.format_on_save(client)
+function M.format_on_save(client, opts)
     if client.supports_method('textDocument/formatting') then
         local lsp_format_augroup = vim.api.nvim_create_augroup('lsp_format_augroup', { clear = true })
         vim.api.nvim_create_autocmd('BufWritePre', {
             group = lsp_format_augroup,
             callback = function()
-                vim.lsp.buf.formatting_sync({}, 1000)
+                vim.lsp.buf.formatting_sync({}, opts.format_on_save_timeout or 1000)
             end,
         })
     end


### PR DESCRIPTION
Since `format_on_save` can not be overwritten now, I've added a configuration param for the timeout.